### PR TITLE
Show not urgent indicator

### DIFF
--- a/src/features/todo/list.tsx
+++ b/src/features/todo/list.tsx
@@ -39,17 +39,22 @@ export const TodoItem = ({ todo }: { todo: Todo }) => {
     };
 
     return (
-        <li className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
+        <li className="flex items-center justify-between gap-6">
+            <div className="flex grow items-center gap-4">
                 <IconButton
                     onClick={toggleDone}
                     loading={updateMutation.isLoading}
                 >
                     {isDone && <Check weight="duotone" />}
                 </IconButton>
-                <span className={clsx(isDone && "line-through")}>
-                    {todo.title}
-                </span>
+                <div className="flex grow items-center justify-between">
+                    <p className={clsx(isDone && "line-through")}>
+                        {todo.title}
+                    </p>
+                    <p className="bg-neutral-50 text-xs text-neutral-500">
+                        {todo.priority === "not_urgent" && "someday"}
+                    </p>
+                </div>
             </div>
             <IconButton onClick={deleteTodo} loading={deleteMutation.isLoading}>
                 <Eraser weight="duotone" />

--- a/src/server/trpc/router/planning.ts
+++ b/src/server/trpc/router/planning.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { prisma } from "../../db/client";
 import { protectedProcedure, router } from "../trpc";
 import type { Todo } from "./todo";
-import { todoSchema } from "./todo";
+import { prioritySchema, todoSchema } from "./todo";
 
 export const planningRouter = router({
     setDayFocus: protectedProcedure
@@ -93,6 +93,7 @@ export const planningRouter = router({
                     title: todo.title,
                     isDone: todo.isDone,
                     goalName: todo.Goal.name,
+                    priority: prioritySchema.parse(todo.priority),
                 };
                 if (todoGroupedByGoal[todo.Goal.name]) {
                     todoGroupedByGoal[todo.Goal.name]?.push(transformedTodo);

--- a/src/server/trpc/router/todo.ts
+++ b/src/server/trpc/router/todo.ts
@@ -9,12 +9,15 @@ const goalSchema = z.object({
 
 export type Goal = z.infer<typeof goalSchema>;
 
+export const prioritySchema = z.enum(["urgent", "not_urgent"]);
+
 export const todoSchema = z.object({
     id: z.string(),
     title: z.string(),
     description: z.string().nullish(),
     isDone: z.date().nullable(),
     goalName: z.string(),
+    priority: prioritySchema,
 });
 
 export type Todo = z.infer<typeof todoSchema>;
@@ -96,7 +99,7 @@ export const todoRouter = router({
                 title: z.string(),
                 description: z.string().nullable(),
                 goalId: z.string(),
-                priority: z.enum(["not_urgent", "urgent"]),
+                priority: prioritySchema,
             })
         )
         .output(todoSchema)
@@ -117,6 +120,7 @@ export const todoRouter = router({
                 title: createdTodo.title,
                 isDone: createdTodo.isDone,
                 goalName: createdTodo.Goal.name,
+                priority: prioritySchema.parse(createdTodo.priority),
             };
             return response;
         }),
@@ -126,7 +130,7 @@ export const todoRouter = router({
                 id: z.string(),
                 title: z.string().optional(),
                 description: z.string().optional(),
-                priority: z.enum(["not_urgent", "urgent"]).optional(),
+                priority: prioritySchema.optional(),
             })
         )
         .output(todoSchema)
@@ -148,6 +152,7 @@ export const todoRouter = router({
                 title: updatedTodo.title,
                 isDone: updatedTodo.isDone,
                 goalName: updatedTodo.Goal.name,
+                priority: prioritySchema.parse(updatedTodo.priority),
             };
             return response;
         }),
@@ -172,7 +177,7 @@ export const todoRouter = router({
         .input(
             z.object({
                 goalIds: z.array(z.string()).default([]),
-                priority: z.enum(["not_urgent", "urgent"]).optional(),
+                priority: prioritySchema.optional(),
             })
         )
         .output(
@@ -197,6 +202,7 @@ export const todoRouter = router({
                     title: todo.title,
                     isDone: todo.isDone,
                     goalName: todo.Goal.name,
+                    priority: prioritySchema.parse(todo.priority),
                 })),
             };
         }),


### PR DESCRIPTION
Resolves #57 
- show `someday` for not urgent todos
- added a better priority schema. `priority` is an enum now and is parsed in the backend with `zod` to get the correct types.
- all todo endpoints now return the todo `priority`

# Screenshot

![image](https://user-images.githubusercontent.com/47036679/221368792-a5231fad-fca2-435c-98b1-3be24126452e.png)
